### PR TITLE
feat: add setup workflow for label management.

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,7 @@
+name: setup
+
+on:
+  workflow_dispatch:
+jobs:
+  setup-labels:
+    uses: HasutoSasaki/github-workflows/.github/workflows/setup-labels.yaml@main


### PR DESCRIPTION
## 📗 Description
This pull request adds a new GitHub Actions workflow for setting up labels in the repository. The workflow can be triggered manually and leverages a reusable workflow from an external source.

## 🔄 Change

* Added a `.github/workflows/setup.yaml` file that defines a `setup` workflow, which uses the `HasutoSasaki/github-workflows/.github/workflows/setup-labels.yaml@main` reusable workflow to automate label setup, triggered via `workflow_dispatch`.


